### PR TITLE
backup/recovery test: exclude firmware files to reduce initrd size

### DIFF
--- a/tests/make-backup-and-restore-iso/runtest.sh
+++ b/tests/make-backup-and-restore-iso/runtest.sh
@@ -96,6 +96,7 @@ rlJournalStart
             rlFileBackup "$REAR_CONFIG"
             rlRun -l "echo 'OUTPUT=ISO
 SSH_FILES=no
+FIRMWARE_FILES=( no )
 BACKUP=NETFS
 BACKUP_URL=iso:///backup
 OUTPUT_URL=null


### PR DESCRIPTION
fixes https://github.com/rear/rear/issues/3107