### PR TITLE
Backup & recovery test: fail early if UEFI found

### DIFF
--- a/tests/make-backup-and-restore-iso/runtest.sh
+++ b/tests/make-backup-and-restore-iso/runtest.sh
@@ -86,6 +86,14 @@ rlJournalStart
             rlAssertRpm --all
         rlPhaseEnd
 
+        rlPhaseStartSetup "Check that we are not on a UEFI machine"
+            rlRun "ls /sys/firmware/ | grep efi" \
+                1 "Check if we are on UEFI machine"
+            if [ $? -eq 0 ]; then
+                rlDie "Machine with UEFI"
+            fi
+        rlPhaseEnd
+
         # Configure ReaR for ISO output.
         # Backup will be embedded in the ISO. Since the ISO is not written/burned
         # to any disk, but merely loaded into RAM by the bootloader (memdisk - see below),


### PR DESCRIPTION
This test needs BIOS. Assume that if UEFI variables are present, the machine has not been booted via BIOS but via UEFI, and abort the test early, before even running ReaR. This provides a more descriptive test failure in the log in case the test machine is not what we expect.

Related: https://github.com/rear/rear/issues/3313

Tested by CI runs on https://github.com/rear/rear/pull/3314 : 
failed test (Fedora 39, VM with UEFI)
```
::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
::   Check that we are not on a UEFI machine
::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

:: [ 16:37:46 ] :: [  BEGIN   ] :: Check if we are on UEFI machine :: actually running 'ls /sys/firmware/ | grep efi'
efi
:: [ 16:37:46 ] :: [   FAIL   ] :: Check if we are on UEFI machine (Expected 1, got 0)
:: [ 16:37:46 ] :: [  FATAL   ] :: Machine with UEFI
:: [ 16:37:46 ] :: [   FAIL   ] :: Machine with UEFI (Assert: expected 0, got 1)
```

successful test (CentOS Stream, VM with BIOS):
```
::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
::   Check that we are not on a UEFI machine
::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

:: [ 16:31:24 ] :: [  BEGIN   ] :: Check if we are on UEFI machine :: actually running 'ls /sys/firmware/ | grep efi'
:: [ 16:31:24 ] :: [   PASS   ] :: Check if we are on UEFI machine (Expected 1, got 1)
::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
::   Duration: 0s
::   Assertions: 1 good, 0 bad
::   RESULT: PASS (Check that we are not on a UEFI machine)
```

Cc @lzaoral